### PR TITLE
Weaken the superclass on `Commutative`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+dist-newstyle/

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- `Commutative (Product a)` now merely requires
-  `Num a`.
+- `Commutative (Product a)` now merely requires `CommutativeProduct a`.
+  `CommutativeProduct` is a new class to indicate `(*)` from Num is
+  commutative, which is not required by `Num`.`
 
 ## 0.0.2.0 -- 2022-03-26
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for commutative-semigroups
 
+## Unreleased
+
+- `Commutative (Product a)` now merely requires
+  `Num a`.
+
 ## 0.0.1.0 -- 2021-01-28
 
 - Add instance for `Maybe`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,24 @@
 
 ## Unreleased
 
-- `Commutative (Product a)` now merely requires `CommutativeProduct a`.
-  `CommutativeProduct` is a new class to indicate `(*)` from Num is
-  commutative, which is not required by `Num`.`
+- `Commutative (Product a)` now requires `CommutativeProduct a`.
+  `CommutativeProduct` is a new class to indicate `(*)` from `Num` is
+  commutative, which is not required by `Num`. (Example:
+  multiplication on
+  [quaternions](https://en.wikipedia.org/wiki/Quaternion) is
+  non-commutative, and the `Quaternion a` type from the `linear`
+  package has a valid `instance RealFloat a => Num (Quaternion a)`.)
+
+  **Remark:** There is also no canonical subclass class in the `Num`
+  hierarchy which implies commutative `(*)`, as both `Integral` and
+  `Floating` instances work here:
+
+  - `Integral` instances are customarily Euclidean Domains, which are
+    commutative rings with extra conditions.
+
+  - `Floating` instances customarily expect `(+)`, `(*)`, and `exp` to
+    form an exponential field, which is also a commutative ring with
+    extra conditions.
 
 ## 0.0.2.0 -- 2022-03-26
 

--- a/commutative-semigroups.cabal
+++ b/commutative-semigroups.cabal
@@ -22,6 +22,7 @@ source-repository head
 
 library
   exposed-modules:     Data.Semigroup.Commutative
+                       Numeric.Product.Commutative
   -- other-modules:
   build-depends:       base >= 4.6 && < 4.17,
                        containers >= 0.4 && < 0.7

--- a/src/Data/Semigroup/Commutative.hs
+++ b/src/Data/Semigroup/Commutative.hs
@@ -24,7 +24,7 @@ import Data.Functor.Identity
 import Data.Functor.Contravariant (Op(Op))
 import GHC.Generics
 #endif
-import TEMP ( CommutativeProduct )
+import Numeric.Product.Commutative ( CommutativeProduct )
 
 -- |An 'Commutative' semigroup is a 'Semigroup' that follows the rule:
 --

--- a/src/Data/Semigroup/Commutative.hs
+++ b/src/Data/Semigroup/Commutative.hs
@@ -42,7 +42,7 @@ instance Commutative a => Commutative (Maybe a)
 
 instance Num a => Commutative (Sum a)
 
-instance Fractional a => Commutative (Product a)
+instance Num a => Commutative (Product a)
 
 instance Commutative a => Commutative (Dual a)
 

--- a/src/Data/Semigroup/Commutative.hs
+++ b/src/Data/Semigroup/Commutative.hs
@@ -24,6 +24,7 @@ import Data.Functor.Identity
 import Data.Functor.Contravariant (Op(Op))
 import GHC.Generics
 #endif
+import TEMP ( CommutativeProduct )
 
 -- |An 'Commutative' semigroup is a 'Semigroup' that follows the rule:
 --
@@ -44,7 +45,7 @@ instance Commutative a => Commutative (Maybe a)
 
 instance Num a => Commutative (Sum a)
 
-instance Num a => Commutative (Product a)
+instance CommutativeProduct a => Commutative (Product a)
 
 instance Commutative a => Commutative (Dual a)
 

--- a/src/Numeric/Product/Commutative.hs
+++ b/src/Numeric/Product/Commutative.hs
@@ -59,6 +59,9 @@ instance CommutativeProduct Word64
 instance CommutativeProduct Word
 instance CommutativeProduct Natural
 
+instance CommutativeProduct Float
+instance CommutativeProduct Double
+
 instance (RealFloat a, CommutativeProduct a) => CommutativeProduct (Complex a)
 
 instance CommutativeProduct a => CommutativeProduct (Identity a)

--- a/src/Numeric/Product/Commutative.hs
+++ b/src/Numeric/Product/Commutative.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-module TEMP
+module Numeric.Product.Commutative
   ( CommutativeProduct (..)
   )
   where

--- a/src/TEMP.hs
+++ b/src/TEMP.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module TEMP
   ( CommutativeProduct (..)
   )
@@ -6,15 +7,18 @@ module TEMP
 import Control.Applicative (Const)
 import Data.Complex (Complex)
 import Data.Fixed
-import Data.Functor.Contravariant (Op)
 import Data.Functor.Identity
 import Data.Int
-import Data.Monoid
 import Data.Ord (Down)
 import Data.Ratio (Ratio)
 import Data.Semigroup (Max, Min, Product, Sum)
 import Data.Word
 import Numeric.Natural
+
+#if MIN_VERSION_base(4, 12, 0)
+import Data.Functor.Contravariant (Op)
+import Data.Monoid (Alt)
+#endif
 
 -- | Subclass of 'Num' where '(*)' is commutative.
 --
@@ -73,10 +77,13 @@ instance (Integral a, CommutativeProduct a) => CommutativeProduct (Ratio a)
 
 instance (HasResolution a, CommutativeProduct a) => CommutativeProduct (Fixed a)
 
-instance CommutativeProduct a => CommutativeProduct (Op a b)
-
 -- @since: base-4.9.0.0
 instance CommutativeProduct a => CommutativeProduct (Const a b)
 
+#if MIN_VERSION_base(4, 12, 0)
+-- @since: base-4.12.0.0
+instance CommutativeProduct a => CommutativeProduct (Op a b)
+
 -- @since: base-4.12.0.0
 instance CommutativeProduct (f a) => CommutativeProduct (Alt f a)
+#endif

--- a/src/TEMP.hs
+++ b/src/TEMP.hs
@@ -6,6 +6,23 @@ module TEMP
 import Data.Int
 import Data.Word
 
+-- | Subclass of 'Num' where '(*)' is commutative.
+--
+-- 'Num' doesn't demand commutative '(*)', and there are reasonable
+-- "real-world" instances with non-commutative multiplication. There
+-- is also no canonical subclass in @base@ that would suffice, as both
+-- 'Integral' and 'Floating' imply commutative '(*)' for different
+-- reasons.
+--
+-- Two examples of non-commutative '(*)':
+--
+-- * @Linear.Quaternion.Quaterion@ from the @linear@ package has a
+--   'Num' instance, and quaternion multiplication is
+--   noncommutative.
+--
+-- * @Data.Matrix.Matrix@ from the @matrix@ package uses '(*)' for
+--   matrix multiplication, which is also non-commutative (on square
+--   matrices, which is the only time the question makes sense).
 class Num a => CommutativeProduct a
 
 instance CommutativeProduct Int8

--- a/src/TEMP.hs
+++ b/src/TEMP.hs
@@ -3,8 +3,18 @@ module TEMP
   )
   where
 
+import Control.Applicative (Const)
+import Data.Complex (Complex)
+import Data.Fixed
+import Data.Functor.Contravariant (Op)
+import Data.Functor.Identity
 import Data.Int
+import Data.Monoid
+import Data.Ord (Down)
+import Data.Ratio (Ratio)
+import Data.Semigroup (Max, Min, Product, Sum)
 import Data.Word
+import Numeric.Natural
 
 -- | Subclass of 'Num' where '(*)' is commutative.
 --
@@ -30,8 +40,43 @@ instance CommutativeProduct Int16
 instance CommutativeProduct Int32
 instance CommutativeProduct Int64
 instance CommutativeProduct Int
+instance CommutativeProduct Integer
+
 instance CommutativeProduct Word8
 instance CommutativeProduct Word16
 instance CommutativeProduct Word32
 instance CommutativeProduct Word64
 instance CommutativeProduct Word
+instance CommutativeProduct Natural
+
+instance (RealFloat a, CommutativeProduct a) => CommutativeProduct (Complex a)
+
+instance CommutativeProduct a => CommutativeProduct (Identity a)
+
+-- @since: base-4.9.0.0
+instance CommutativeProduct a => CommutativeProduct (Down a)
+
+-- @since: base-4.11.0.0
+instance CommutativeProduct a => CommutativeProduct (Max a)
+
+-- @since: base-4.9.0.0
+instance CommutativeProduct a => CommutativeProduct (Min a)
+
+-- @since: base-4.9.0.0
+instance CommutativeProduct a => CommutativeProduct (Product a)
+
+-- @since: base-4.7.0.0
+instance CommutativeProduct a => CommutativeProduct (Sum a)
+
+-- @since: base-4.7.0.0
+instance (Integral a, CommutativeProduct a) => CommutativeProduct (Ratio a)
+
+instance (HasResolution a, CommutativeProduct a) => CommutativeProduct (Fixed a)
+
+instance CommutativeProduct a => CommutativeProduct (Op a b)
+
+-- @since: base-4.9.0.0
+instance CommutativeProduct a => CommutativeProduct (Const a b)
+
+-- @since: base-4.12.0.0
+instance CommutativeProduct (f a) => CommutativeProduct (Alt f a)

--- a/src/TEMP.hs
+++ b/src/TEMP.hs
@@ -1,0 +1,20 @@
+module TEMP
+  ( CommutativeProduct (..)
+  )
+  where
+
+import Data.Int
+import Data.Word
+
+class Num a => CommutativeProduct a
+
+instance CommutativeProduct Int8
+instance CommutativeProduct Int16
+instance CommutativeProduct Int32
+instance CommutativeProduct Int64
+instance CommutativeProduct Int
+instance CommutativeProduct Word8
+instance CommutativeProduct Word16
+instance CommutativeProduct Word32
+instance CommutativeProduct Word64
+instance CommutativeProduct Word

--- a/src/TEMP.hs
+++ b/src/TEMP.hs
@@ -9,11 +9,17 @@ import Data.Complex (Complex)
 import Data.Fixed
 import Data.Functor.Identity
 import Data.Int
-import Data.Ord (Down)
 import Data.Ratio (Ratio)
-import Data.Semigroup (Max, Min, Product, Sum)
 import Data.Word
 import Numeric.Natural
+
+#if MIN_VERSION_base(4, 9, 0)
+import Data.Semigroup (Max, Min, Product, Sum)
+#endif
+
+#if MIN_VERSION_base(4, 11, 0)
+import Data.Ord (Down)
+#endif
 
 #if MIN_VERSION_base(4, 12, 0)
 import Data.Functor.Contravariant (Op)
@@ -57,18 +63,6 @@ instance (RealFloat a, CommutativeProduct a) => CommutativeProduct (Complex a)
 
 instance CommutativeProduct a => CommutativeProduct (Identity a)
 
--- @since: base-4.9.0.0
-instance CommutativeProduct a => CommutativeProduct (Down a)
-
--- @since: base-4.11.0.0
-instance CommutativeProduct a => CommutativeProduct (Max a)
-
--- @since: base-4.9.0.0
-instance CommutativeProduct a => CommutativeProduct (Min a)
-
--- @since: base-4.9.0.0
-instance CommutativeProduct a => CommutativeProduct (Product a)
-
 -- @since: base-4.7.0.0
 instance CommutativeProduct a => CommutativeProduct (Sum a)
 
@@ -77,8 +71,24 @@ instance (Integral a, CommutativeProduct a) => CommutativeProduct (Ratio a)
 
 instance (HasResolution a, CommutativeProduct a) => CommutativeProduct (Fixed a)
 
+#if MIN_VERSION_base(4, 9, 0)
+-- @since: base-4.9.0.0
+instance CommutativeProduct a => CommutativeProduct (Min a)
+
+-- @since: base-4.9.0.0
+instance CommutativeProduct a => CommutativeProduct (Max a)
+
+-- @since: base-4.9.0.0
+instance CommutativeProduct a => CommutativeProduct (Product a)
+
 -- @since: base-4.9.0.0
 instance CommutativeProduct a => CommutativeProduct (Const a b)
+#endif
+
+#if MIN_VERSION_base(4, 11, 0)
+-- @since: base-4.11.0.0
+instance CommutativeProduct a => CommutativeProduct (Down a)
+#endif
 
 #if MIN_VERSION_base(4, 12, 0)
 -- @since: base-4.12.0.0


### PR DESCRIPTION
That it was something as strong as `Fractional` was a relic of the `Group` superclass to `Abelian` I stripped away to make this package.

However, `Num`'s suggested laws do not come with commutativity for
`(*)`. Should we do this anyways? or should we have a
```haskell
class Num a => CommutativeMultiplication a
```
helper class so we can do
```haskell
instance CommutativeMultiplication a => Commutative (Product a)
```
?

CC @cgibbard @madeline-os @endgame @Taneb

@Taneb in particular, note that the safer `CommutativeMultiplication` would be a breaking change for `groups`.