### PR TITLE
Allow base-4.17

### DIFF
--- a/commutative-semigroups.cabal
+++ b/commutative-semigroups.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 name:                commutative-semigroups
 version:             0.1.0.0
-x-revision:          1
+x-revision:          2
 synopsis:            Commutative semigroups
 description:
   A commutative semigroup is a semigroup where the order of arguments to mappend does not matter.
@@ -25,7 +25,7 @@ library
   exposed-modules:     Data.Semigroup.Commutative
                        Numeric.Product.Commutative
   -- other-modules:
-  build-depends:       base >= 4.6 && < 4.17,
+  build-depends:       base >= 4.6 && < 4.18,
                        containers >= 0.4 && < 0.7
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
As a Hackage trustee, I made a relevant revision: https://hackage.haskell.org/package/commutative-semigroups-0.1.0.0/revisions/