### PR TITLE
Support GHC `9.6.1`.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,7 +18,7 @@ jobs:
 
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2', '9.0.1', '9.2.1', '9.4.1']
+        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2', '9.0.1', '9.2.1', '9.4.1', '9.6.1']
         os: ['ubuntu-latest', 'macos-latest']
         exclude:
           # There are some linker warnings in 802 on darwin that

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,7 +19,7 @@ jobs:
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
     - name: Cache

--- a/commutative-semigroups.cabal
+++ b/commutative-semigroups.cabal
@@ -25,7 +25,7 @@ library
   exposed-modules:     Data.Semigroup.Commutative
                        Numeric.Product.Commutative
   -- other-modules:
-  build-depends:       base >= 4.6 && < 4.18,
+  build-depends:       base >= 4.6 && < 4.19,
                        containers >= 0.4 && < 0.7
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This PR:
- Updates the upper bound on `base` to `< 4.19`.
- Adds GHC `9.6.1` to the CI build workflow.
- Upgrades CI to use the latest version of `haskell/action/setup`.
- Upgrades CI to use the latest version of `actions/checkout`.