### PR TITLE
Add Windows to CI build matrix.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.7', '9.0.2', '9.2.8', '9.4.7', '9.6.3', '9.8.1']
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         exclude:
           # There are some linker warnings in 802 on darwin that
           # cause compilation to fail


### PR DESCRIPTION
## Summary

This PR extends the CI build matrix so that it includes Windows, for all supported GHC versions.

## Motivation

Help us to detect changes that fail to build on Windows. For example: https://github.com/obsidiansystems/commutative-semigroups/issues/17.

This does mean that CI might take a little longer to complete, but since `commutative-semigroups` is a transitive dependency of many packages (including HLS), it's probably good to err on the side of caution.